### PR TITLE
[codex] Fix persistence effector actor names

### DIFF
--- a/library/src/main/scala/com/github/j5ik2o/pekko/persistence/effector/scaladsl/PersistenceEffector.scala
+++ b/library/src/main/scala/com/github/j5ik2o/pekko/persistence/effector/scaladsl/PersistenceEffector.scala
@@ -7,9 +7,12 @@ import com.github.j5ik2o.pekko.persistence.effector.internal.scalaimpl.{
   InMemoryEffector,
   PersistenceStoreActor,
 }
+import org.apache.pekko.actor.ActorPath
 import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import scala.compiletime.asMatchable
 
 /**
@@ -144,6 +147,15 @@ trait PersistenceEffector[S, E, M] {
 object PersistenceEffector {
   // Message for handling recovery completion internally
   private case class RecoveryCompletedInternal[S](state: S, sequenceNr: Long)
+
+  private[effector] def persistenceStoreActorName(persistenceId: String): String = {
+    val actorName = s"effector-${URLEncoder.encode(persistenceId, StandardCharsets.UTF_8)}"
+    require(
+      ActorPath.isValidPathElement(actorName),
+      s"Generated persistence store actor name is invalid: $actorName",
+    )
+    actorName
+  }
 
   /**
    * Create a PersistenceEffector in persisted mode.
@@ -400,7 +412,7 @@ object PersistenceEffector {
           recoveryAdapter,
           backoffConfig,
         ),
-        s"effector-${persistenceId.asString}",
+        persistenceStoreActorName(persistenceId.asString),
       )
       .toTyped
   }

--- a/library/src/test/scala/com/github/j5ik2o/pekko/persistence/effector/internal/scalaimpl/PersistedEffectorSpec.scala
+++ b/library/src/test/scala/com/github/j5ik2o/pekko/persistence/effector/internal/scalaimpl/PersistedEffectorSpec.scala
@@ -1,8 +1,18 @@
 package com.github.j5ik2o.pekko.persistence.effector.internal.scalaimpl
 
-import com.github.j5ik2o.pekko.persistence.effector.scaladsl.PersistenceMode
+import com.github.j5ik2o.pekko.persistence.effector.scaladsl.{
+  PersistenceEffector,
+  PersistenceEffectorConfig,
+  PersistenceId,
+  PersistenceMode,
+}
+import com.github.j5ik2o.pekko.persistence.effector.{TestEvent, TestMessage, TestState}
+import org.apache.pekko.actor.ActorPath
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
 
 import java.io.File
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.*
 
 /**
  * Test for PersistenceEffector using Persisted mode
@@ -12,6 +22,75 @@ class PersistedEffectorSpec extends PersistenceEffectorTestBase {
 
   // Run snapshot tests
   override def runSnapshotTests: Boolean = true
+
+  "PersistenceEffector persisted actor names" should {
+    "encode persistence ids into valid non-colliding actor names" in {
+      val actorNames = Seq(
+        "Staff|01KM",
+        "Staff/01KM with space",
+        "Staff|\u65e5\u672c\u8a9e",
+      ).map(PersistenceEffector.persistenceStoreActorName)
+
+      actorNames.foreach { actorName =>
+        actorName should startWith("effector-")
+        ActorPath.isValidPathElement(actorName) shouldBe true
+      }
+
+      PersistenceEffector.persistenceStoreActorName("A|B") should not be PersistenceEffector.persistenceStoreActorName(
+        "A_B")
+    }
+  }
+
+  "PersistenceEffector with a typed persistence id" should {
+    "persist and recover using the original separator-based persistence id" in {
+      val entityId = s"staff-${java.util.UUID.randomUUID()}"
+      val persistenceId = PersistenceId.of("Staff", entityId)
+      val initialState = TestState()
+      val event = TestEvent.TestEventA("hired")
+
+      persistenceId.asString shouldBe s"Staff|$entityId"
+
+      val config =
+        PersistenceEffectorConfig.create[TestState, TestEvent, TestMessage](
+          persistenceId = persistenceId,
+          initialState = initialState,
+          applyEvent = (state, event) => state.applyEvent(event),
+          stashSize = Int.MaxValue,
+          persistenceMode = persistenceMode,
+          snapshotCriteria = None,
+          retentionCriteria = None,
+          backoffConfig = None,
+          messageConverter = messageConverter,
+        )
+
+      val persistedEvents = ArrayBuffer.empty[TestMessage]
+
+      spawn(Behaviors.setup[TestMessage] { context =>
+        PersistenceEffector.fromConfig[TestState, TestEvent, TestMessage](config) { case (_, effector) =>
+          effector.persistEvent(event) { _ =>
+            persistedEvents += TestMessage.EventPersisted(Seq(event))
+            Behaviors.stopped
+          }
+        }(using context)
+      })
+
+      eventually {
+        persistedEvents.size shouldBe 1
+      }
+
+      val recoveredProbe = createTestProbe[TestState]()
+
+      spawn(Behaviors.setup[TestMessage] { context =>
+        PersistenceEffector.fromConfig[TestState, TestEvent, TestMessage](config) { case (state, _) =>
+          recoveredProbe.ref ! state
+          Behaviors.stopped
+        }(using context)
+      })
+
+      val recoveredState = recoveredProbe.receiveMessage(10.seconds)
+      recoveredState.values should contain("hired")
+    }
+  }
 
   // Ensure LevelDB storage directory is created before testing
   override def beforeAll(): Unit = {


### PR DESCRIPTION
## Summary

Fixes #198.

`PersistenceEffector` was using `PersistenceId.asString` both as the persistence key and as the child actor name. Pekko's standard typed persistence id format uses `|` between the type hint and entity id, but `|` is not valid in actor path elements, so `PersistenceId.of("Staff", entityId)` could fail with `InvalidActorNameException`.

This PR keeps the original persistence id for journal/snapshot storage and encodes only the internal persistence store actor name.

## Changes

- Add an internal actor-name helper that `URLEncoder`-encodes the full persistence id and validates the result with `ActorPath.isValidPathElement`.
- Use the encoded name only for `actorOf`; `PersistenceStoreActor.props` still receives the original `persistenceId.asString`.
- Add persisted-mode regression coverage for type-hint persistence ids and actor-name edge cases.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- sbt "library/testOnly *PersistedEffectorSpec *PersistenceIdSpec"`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- sbt scalafmtCheckAll`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- sbt library/test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to how the internal persistence store child actor is named, with added validation and regression tests; persistence journal/snapshot keys remain unchanged.
> 
> **Overview**
> Fixes persisted-mode actor spawn failures when `PersistenceId.asString` contains characters invalid for Pekko actor path elements (notably the `|` typed-persistence separator).
> 
> `PersistenceEffector` now derives the child persistence store actor name via `URLEncoder` + `ActorPath.isValidPathElement` validation, while still passing the original `persistenceId.asString` to `PersistenceStoreActor` for storage. Adds persisted-mode tests covering encoded/non-colliding actor names and successful persist+recovery using separator-based typed persistence IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a271519bb345041fd58a75988ee519d6d9202ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->